### PR TITLE
SeatTouch: fix callbacks handling

### DIFF
--- a/src/displayBackend/wayland/SeatDevice.hpp
+++ b/src/displayBackend/wayland/SeatDevice.hpp
@@ -50,9 +50,11 @@ public:
 
 protected:
 
+	typedef typename std::unordered_map<wl_surface*, T>::iterator CallbackIt;
+
 	std::mutex mMutex;
 	std::unordered_map<wl_surface*, T> mCallbacks;
-	typename std::unordered_map<wl_surface*, T>::iterator mCurrentCallback;
+	CallbackIt mCurrentCallback;
 };
 
 }

--- a/src/displayBackend/wayland/SeatTouch.hpp
+++ b/src/displayBackend/wayland/SeatTouch.hpp
@@ -32,6 +32,7 @@ private:
 	wl_touch* mWlTouch;
 	wl_touch_listener mListener;
 	XenBackend::Log mLog;
+	std::unordered_map<int32_t, CallbackIt> mCallbackIdMap;
 
 	static void sOnDown(void* data, wl_touch* touch, uint32_t serial,
 						uint32_t time, wl_surface* surface, int32_t id,


### PR DESCRIPTION
Each seat device uses mCurrentCallback field to keep
frontend handler when input device entered the surface.
It is ok for keyboard and mouse but in case multitouch
user can press different surface with different touch ID
and using one current callback is not enough. The fix is
to have current callback per touch ID.

Signed-off-by: Oleksandr Grytsov <Oleksandr_Grytsov@epam.com>