### PR TITLE
Fix local variable initialization in FrameBuffer::init

### DIFF
--- a/src/displayBackend/drm/FrameBuffer.cpp
+++ b/src/displayBackend/drm/FrameBuffer.cpp
@@ -74,7 +74,7 @@ FrameBuffer::~FrameBuffer()
 
 void FrameBuffer::init(uint32_t pixelFormat)
 {
-	uint32_t handles[4], pitches[4], offsets[4] = {0};
+	uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0};
 
 	handles[0] = mDisplayBuffer->getHandle();
 	pitches[0] = mDisplayBuffer->getStride();


### PR DESCRIPTION
Signed-off-by: Oleksandr Grytsov <Oleksandr_Grytsov@epam.com>