### PR TITLE
Wayland: create wl surface on init connector and destroy on release

### DIFF
--- a/src/displayBackend/wayland/CMakeLists.txt
+++ b/src/displayBackend/wayland/CMakeLists.txt
@@ -3,7 +3,6 @@ add_subdirectory(protocols)
 set(SOURCES
 	Compositor.cpp
 	Connector.cpp
-	ConnectorManager.cpp
 	Display.cpp
 	SharedBuffer.cpp
 	SharedFile.cpp
@@ -11,6 +10,7 @@ set(SOURCES
 	Shell.cpp
 	ShellSurface.cpp
 	Surface.cpp
+	SurfaceManager.cpp
 )
 
 if(WITH_DRM)

--- a/src/displayBackend/wayland/Display.cpp
+++ b/src/displayBackend/wayland/Display.cpp
@@ -125,8 +125,7 @@ DisplayItf::ConnectorPtr Display::createConnector(const string& name)
 
 	if (mShell)
 	{
-		connector = new ShellConnector(name, mShell,
-									   mCompositor->createSurface());
+		connector = new ShellConnector(name, mShell, mCompositor);
 
 		LOG(mLog, DEBUG) << "Create shell connector, name: " << name;
 	}
@@ -144,15 +143,15 @@ DisplayItf::ConnectorPtr Display::createConnector(const string& name)
 			throw Exception("Can't create surface id: " + name, -EINVAL);
 		}
 
-		connector = new IviConnector(name, mIviApplication,
-									 mCompositor->createSurface(), surfaceId);
+		connector = new IviConnector(name, mIviApplication, mCompositor,
+									 surfaceId);
 
 		LOG(mLog, DEBUG) << "Create ivi connector, name: " << name;
 	}
 #endif
 	else
 	{
-		connector = new Connector(name, mCompositor->createSurface());
+		connector = new Connector(name, mCompositor);
 
 		LOG(mLog, DEBUG) << "Create connector, name: " << name;
 	}

--- a/src/displayBackend/wayland/SeatDevice.hpp
+++ b/src/displayBackend/wayland/SeatDevice.hpp
@@ -11,13 +11,13 @@
 #include <mutex>
 #include <unordered_map>
 
-#include "ConnectorManager.hpp"
 #include "Surface.hpp"
+#include "SurfaceManager.hpp"
 
 namespace Wayland {
 
 template<typename T>
-class SeatDevice : public ConnectorNotificationItf
+class SeatDevice : public SurfaceNotificationItf
 {
 public:
 
@@ -32,7 +32,7 @@ public:
 
 		mConnectorCallbacks[connector] = callbacks;
 
-		auto surface = ConnectorManager::getInstance().getSurfaceByName(connector);
+		auto surface = SurfaceManager::getInstance().getSurfaceByConnectorName(connector);
 
 		if (surface)
 		{
@@ -44,7 +44,7 @@ public:
 	{
 		std::lock_guard<std::mutex> lock(mMutex);
 
-		auto surface = ConnectorManager::getInstance().getSurfaceByName(connector);
+		auto surface = SurfaceManager::getInstance().getSurfaceByConnectorName(connector);
 
 		if (surface)
 		{

--- a/src/displayBackend/wayland/SeatKeyboard.cpp
+++ b/src/displayBackend/wayland/SeatKeyboard.cpp
@@ -92,7 +92,7 @@ void SeatKeyboard::onEnter(uint32_t serial, wl_surface* surface, wl_array* keys)
 	lock_guard<mutex> lock(mMutex);
 
 	DLOG(mLog, DEBUG) << "onEnter connector: "
-					  << ConnectorManager::getInstance().getNameBySurface(surface)
+					  << SurfaceManager::getInstance().getConnectorNameBySurface(surface)
 					  << ", serial: " << serial;
 
 	mCurrentCallback = mSurfaceCallbacks.find(surface);
@@ -103,7 +103,7 @@ void SeatKeyboard::onLeave(uint32_t serial, wl_surface* surface)
 	lock_guard<mutex> lock(mMutex);
 
 	DLOG(mLog, DEBUG) << "onLeave connector: "
-					  << ConnectorManager::getInstance().getNameBySurface(surface)
+					  << SurfaceManager::getInstance().getConnectorNameBySurface(surface)
 					  << ", serial: " << serial;
 
 	mCurrentCallback = mSurfaceCallbacks.end();

--- a/src/displayBackend/wayland/SeatPointer.cpp
+++ b/src/displayBackend/wayland/SeatPointer.cpp
@@ -111,7 +111,7 @@ void SeatPointer::onEnter(uint32_t serial, wl_surface* surface,
 	int32_t resY = wl_fixed_to_int(y);
 
 	DLOG(mLog, DEBUG) << "onEnter connector: "
-					  << ConnectorManager::getInstance().getNameBySurface(surface)
+					  << SurfaceManager::getInstance().getConnectorNameBySurface(surface)
 					  << ", serial: " << serial
 					  << ", X: " << resX << ", Y: " << resY;
 
@@ -126,7 +126,7 @@ void SeatPointer::onLeave(uint32_t serial, wl_surface* surface)
 	lock_guard<mutex> lock(mMutex);
 
 	DLOG(mLog, DEBUG) << "onLeave connector: "
-					  << ConnectorManager::getInstance().getNameBySurface(surface)
+					  << SurfaceManager::getInstance().getConnectorNameBySurface(surface)
 					  << ", serial: " << serial;
 
 	mCurrentCallback = mSurfaceCallbacks.end();

--- a/src/displayBackend/wayland/SeatTouch.cpp
+++ b/src/displayBackend/wayland/SeatTouch.cpp
@@ -87,7 +87,7 @@ void SeatTouch::onDown(uint32_t serial, uint32_t time, wl_surface* surface,
 	int32_t resY = wl_fixed_to_int(y);
 
 	DLOG(mLog, DEBUG) << "onDown connector: "
-					  << ConnectorManager::getInstance().getNameBySurface(surface)
+					  << SurfaceManager::getInstance().getConnectorNameBySurface(surface)
 					  << ", serial: " << serial << ", time: " << time
 					  << ", id: " << id << ", X: " << resX << ", Y: " << resY;
 

--- a/src/displayBackend/wayland/SurfaceManager.cpp
+++ b/src/displayBackend/wayland/SurfaceManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  ConnectorManager class
+ *  SurfaceManager class
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
  *
  */
 
-#include "ConnectorManager.hpp"
+#include "SurfaceManager.hpp"
 
 #include "Exception.hpp"
 
@@ -35,14 +35,14 @@ namespace Wayland {
  * ConnectorManager
  ******************************************************************************/
 
-ConnectorManager& ConnectorManager::getInstance()
+SurfaceManager& SurfaceManager::getInstance()
 {
-	static ConnectorManager sConnectorManager;
+	static SurfaceManager sConnectorManager;
 
 	return sConnectorManager;
 }
 
-void ConnectorManager::createConnector(const string& name, wl_surface* surface)
+void SurfaceManager::createSurface(const string& name, wl_surface* surface)
 {
 	lock_guard<mutex> lock(mMutex);
 
@@ -54,7 +54,7 @@ void ConnectorManager::createConnector(const string& name, wl_surface* surface)
 	}
 }
 
-void ConnectorManager::deleteConnector(const string& name, wl_surface* surface)
+void SurfaceManager::deleteSurface(const string& name, wl_surface* surface)
 {
 	lock_guard<mutex> lock(mMutex);
 
@@ -66,11 +66,11 @@ void ConnectorManager::deleteConnector(const string& name, wl_surface* surface)
 	mSurfaces.erase(name);
 }
 
-wl_surface* ConnectorManager::getSurfaceByName(const string& name)
+wl_surface* SurfaceManager::getSurfaceByConnectorName(const string& connectorName)
 {
 	lock_guard<mutex> lock(mMutex);
 
-	auto it = mSurfaces.find(name);
+	auto it = mSurfaces.find(connectorName);
 
 	if (it != mSurfaces.end())
 	{
@@ -80,7 +80,7 @@ wl_surface* ConnectorManager::getSurfaceByName(const string& name)
 	return nullptr;
 }
 
-string ConnectorManager::getNameBySurface(wl_surface* surface)
+string SurfaceManager::getConnectorNameBySurface(wl_surface* surface)
 {
 	lock_guard<mutex> lock(mMutex);
 

--- a/src/displayBackend/wayland/SurfaceManager.hpp
+++ b/src/displayBackend/wayland/SurfaceManager.hpp
@@ -1,5 +1,5 @@
 /*
- *  ConnectorManager class
+ *  SurfaceManager class
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SRC_WAYLAND_CONNECTORMANAGER_HPP_
-#define SRC_WAYLAND_CONNECTORMANAGER_HPP_
+#ifndef SRC_WAYLAND_SURFACEMANAGER_HPP_
+#define SRC_WAYLAND_SURFACEMANAGER_HPP_
 
 #include <list>
 #include <mutex>
@@ -31,43 +31,43 @@
 
 namespace Wayland {
 
-class ConnectorNotificationItf
+class SurfaceNotificationItf
 {
 public:
-	virtual ~ConnectorNotificationItf() {};
+	virtual ~SurfaceNotificationItf() {};
 	virtual void onConnectorCreate(const std::string& name,
 								   wl_surface* surface) = 0;
 	virtual void onConnectorDelete(const std::string& name,
 								   wl_surface* surface) = 0;
 };
 
-class ConnectorManager
+class SurfaceManager
 {
 public:
 
-	ConnectorManager(const ConnectorManager&) = delete;
-	void operator=(const ConnectorManager&) = delete;
+	SurfaceManager(const SurfaceManager&) = delete;
+	void operator=(const SurfaceManager&) = delete;
 
-	static ConnectorManager& getInstance();
+	static SurfaceManager& getInstance();
 
-	void createConnector(const std::string& name, wl_surface* surface);
-	void deleteConnector(const std::string& name, wl_surface* surface);
+	void createSurface(const std::string& connectorName, wl_surface* surface);
+	void deleteSurface(const std::string& connectorName, wl_surface* surface);
 
-	wl_surface* getSurfaceByName(const std::string& name);
-	std::string getNameBySurface(wl_surface* surface);
+	wl_surface* getSurfaceByConnectorName(const std::string& connectorName);
+	std::string getConnectorNameBySurface(wl_surface* surface);
 
-	void subscribe(ConnectorNotificationItf* subscriber);
-	void unsubscribe(ConnectorNotificationItf* subscriber);
+	void subscribe(SurfaceNotificationItf* subscriber);
+	void unsubscribe(SurfaceNotificationItf* subscriber);
 
 private:
 
-	ConnectorManager() = default;
+	SurfaceManager() = default;
 
-	std::list<ConnectorNotificationItf*> mSubscribers;
+	std::list<SurfaceNotificationItf*> mSubscribers;
 	std::unordered_map<std::string, wl_surface*> mSurfaces;
 	std::mutex mMutex;
 };
 
 }
 
-#endif /* SRC_WAYLAND_CONNECTORMANAGER_HPP_ */
+#endif /* SRC_WAYLAND_SURFACEMANAGER_HPP_ */


### PR DESCRIPTION
Currently wl surface is created once per connector. On init/release shell surface is created/destroyed
and it is not possible to reuse wl surface. The fix is pass wl compositor to connector and create/delete
surface together with shell surface.

Signed-off-by: Oleksandr Grytsov <Oleksandr_Grytsov@epam.com>