### PR TITLE
Wait for the zero-copy buffer to be freed

### DIFF
--- a/src/displayBackend/drm/Dumb.hpp
+++ b/src/displayBackend/drm/Dumb.hpp
@@ -186,9 +186,16 @@ public:
 
 private:
 
+	/**
+	 * Ideally this time-out should be less than the default
+	 * time-out used by the frontend driver to wait for our response
+	 */
+	const int cBufZCopyWaitHandleToMs = 2000;
+
 	int mZCopyFd;
 	uint32_t mBufZCopyHandle;
 	uint32_t mBufZCopyFd;
+	uint32_t mBufZCopyWaitHandle;
 
 	void createDumb(uint32_t bpp, domid_t domId,
 					const DisplayItf::GrantRefs& refs);


### PR DESCRIPTION
Block until dumb buffer with the wait handle provided be freed:
this is needed for synchronization between frontend and backend in case
frontend provides grant references of the buffer via
DRM_XEN_ZCOPY_DUMB_FROM_REFS IOCTL and which must be released before
backend replies with XENDISPL_OP_DBUF_DESTROY response.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>