### PR TITLE
Make errno check portable

### DIFF
--- a/src/displayBackend/drm/Dumb.cpp
+++ b/src/displayBackend/drm/Dumb.cpp
@@ -310,7 +310,7 @@ void DumbZCopyFront::release()
 
 		int ret = drmIoctl(mZCopyFd, DRM_IOCTL_XEN_ZCOPY_DUMB_WAIT_FREE, &waitReq);
 
-		if (ret < 0 && errno != ENOENT)
+		if ((ret < 0) && (errno != ENOENT))
 		{
 			DLOG(mLog, ERROR) << "Wait for buffer failed, force releasing"
 							  << ", error: " << strerror(errno)

--- a/src/displayBackend/wayland/Display.cpp
+++ b/src/displayBackend/wayland/Display.cpp
@@ -112,7 +112,7 @@ void Display::flush()
 
 	int result = 0;
 
-	while((result = wl_display_flush(mWlDisplay) < 0) && errno == EAGAIN);
+	while((result = wl_display_flush(mWlDisplay) < 0) && (errno == EAGAIN));
 
 	if (result < 0)
 	{
@@ -531,7 +531,7 @@ void Display::dispatchThread()
 				DLOG(mLog, DEBUG) << "Dispatch events: " << val;
 			}
 
-			if (wl_display_flush(mWlDisplay) < 0 && errno != EAGAIN)
+			if ((wl_display_flush(mWlDisplay) < 0) && (errno != EAGAIN))
 			{
 				throw Exception("Can't flush events",
 								-wl_display_get_error(mWlDisplay));


### PR DESCRIPTION
There is a portability note on errno usage:
https://www.gnu.org/software/libc/manual/html_node/Checking-for-Errors.html

"Portability Note: ISO C specifies errno as a "modifiable lvalue" rather
than as a variable, permitting it to be implemented as a macro."

Use brackets around errno check for code portability.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>