### PR TITLE
Fix wayland error handling

### DIFF
--- a/src/displayBackend/wayland/Display.cpp
+++ b/src/displayBackend/wayland/Display.cpp
@@ -551,20 +551,27 @@ void Display::dispatchThread()
 	{
 		auto err = wl_display_get_error(mWlDisplay);
 
-		if (err == EPROTO)
+		if (err)
 		{
-			const wl_interface *interface;
-			uint32_t id;
+			if (err == EPROTO)
+			{
+				const wl_interface *interface;
+				uint32_t id;
 
-			auto code = wl_display_get_protocol_error(mWlDisplay, &interface,
-													  &id);
-			LOG(mLog, ERROR) << "Wayland proto error, itd: "
-							 << interface->name
-							 << ", code: " << code;
+				auto code = wl_display_get_protocol_error(mWlDisplay, &interface,
+														  &id);
+				LOG(mLog, ERROR) << "Wayland proto error, itf: "
+								 << interface->name
+								 << ", code: " << code;
+			}
+			else
+			{
+				LOG(mLog, ERROR) << "Wayland error, code: " << strerror(err);
+			}
 		}
 		else
 		{
-			LOG(mLog, ERROR) << "Wayland error, code: " << strerror(err);
+			LOG(mLog, ERROR) << e.what();
 		}
 	}
 


### PR DESCRIPTION
In wayland dispatch thread other than wayland errors
may occur. The fix checks if there was wayland error
then handle wayland error otherwise print exception
message.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>