### PR TITLE
Wayland: do not delete surface if it is deleted on release connector

### DIFF
--- a/src/displayBackend/wayland/Connector.cpp
+++ b/src/displayBackend/wayland/Connector.cpp
@@ -95,9 +95,12 @@ void Connector::onRelease()
 {
 	LOG(mLog, DEBUG) << "Release, name: " << mName;
 
-	SurfaceManager::getInstance().deleteSurface(mName, mSurface->mWlSurface);
+	if (mSurface)
+	{
+		SurfaceManager::getInstance().deleteSurface(mName, mSurface->mWlSurface);
 
-	mSurface.reset();
+		mSurface.reset();
+	}
 }
 
 }


### PR DESCRIPTION
Calling release connector if it is released is valid case.
This patch add checking to allow release on released connector.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>