### PR TITLE
Wayland: add handling of unsupported pixel format

### DIFF
--- a/src/displayBackend/wayland/FrameBuffer.cpp
+++ b/src/displayBackend/wayland/FrameBuffer.cpp
@@ -28,13 +28,6 @@ using std::setw;
 
 using DisplayItf::DisplayBufferPtr;
 
-#ifndef DRM_FORMAT_ARGB8888
-#define DRM_FORMAT_ARGB8888           0x34325241
-#endif
-#ifndef DRM_FORMAT_XRGB8888
-#define DRM_FORMAT_XRGB8888           0x34325258
-#endif
-
 namespace Wayland {
 
 /*******************************************************************************
@@ -118,21 +111,6 @@ SharedBuffer::~SharedBuffer()
 	release();
 }
 
-uint32_t SharedBuffer::convertPixelFormat(uint32_t format)
-{
-	if (format == DRM_FORMAT_ARGB8888)
-	{
-		return WL_SHM_FORMAT_ARGB8888;
-	}
-
-	if (format == DRM_FORMAT_XRGB8888)
-	{
-		return WL_SHM_FORMAT_XRGB8888;
-	}
-
-	return format;
-}
-
 void SharedBuffer::init(wl_shm* wlSharedMemory, uint32_t pixelFormat)
 {
 	mWlPool = wl_shm_create_pool(wlSharedMemory, mDisplayBuffer->getFd(),
@@ -145,7 +123,7 @@ void SharedBuffer::init(wl_shm* wlSharedMemory, uint32_t pixelFormat)
 
 	mWlBuffer = wl_shm_pool_create_buffer(mWlPool, 0, mWidth, mHeight,
 										  mDisplayBuffer->getStride(),
-										  convertPixelFormat(pixelFormat));
+										  pixelFormat);
 
 	if (!mWlBuffer)
 	{

--- a/src/displayBackend/wayland/FrameBuffer.hpp
+++ b/src/displayBackend/wayland/FrameBuffer.hpp
@@ -115,8 +115,6 @@ private:
 
 	void init(wl_shm* wlSharedMemory, uint32_t pixelFormat);
 	void release();
-
-	uint32_t convertPixelFormat(uint32_t format);
 };
 
 typedef std::shared_ptr<SharedBuffer> SharedBufferPtr;

--- a/src/displayBackend/wayland/SharedMemory.hpp
+++ b/src/displayBackend/wayland/SharedMemory.hpp
@@ -8,6 +8,7 @@
 #ifndef SRC_WAYLAND_SHAREDMEMORY_HPP_
 #define SRC_WAYLAND_SHAREDMEMORY_HPP_
 
+#include <list>
 #include <memory>
 
 #include <xen/be/Log.hpp>
@@ -62,12 +63,17 @@ private:
 
 	wl_shm_listener mWlListener;
 
+	std::list<uint32_t> mSupportedFormats;
+
 	static void sFormatHandler(void *data, wl_shm *wlShm, uint32_t format);
 
 	void formatHandler(uint32_t format);
 
 	void init();
 	void release();
+
+	uint32_t convertPixelFormat(uint32_t format);
+	bool isPixelFormatSupported(uint32_t format);
 };
 
 typedef std::shared_ptr<SharedMemory> SharedMemoryPtr;

--- a/src/displayBackend/wayland/WaylandZCopy.hpp
+++ b/src/displayBackend/wayland/WaylandZCopy.hpp
@@ -22,6 +22,7 @@
 #ifndef SRC_WAYLAND_WAYLANDDRM_HPP_
 #define SRC_WAYLAND_WAYLANDDRM_HPP_
 
+#include <list>
 #include <mutex>
 #include <string>
 
@@ -30,6 +31,7 @@
 #include "drm/Display.hpp"
 #include "Registry.hpp"
 #include "wayland-drm-client-protocol.h"
+#include "wayland-kms-client-protocol.h"
 
 namespace Wayland {
 
@@ -56,6 +58,8 @@ protected:
 
 	std::mutex mMutex;
 
+	std::list<uint32_t> mSupportedFormats;
+
 	WaylandZCopy(wl_registry* registry, uint32_t id, uint32_t version);
 
 	virtual void authenticate() = 0;
@@ -63,6 +67,8 @@ protected:
 	void onDevice(const std::string& name);
 	void onFormat(uint32_t format);
 	void onAuthenticated();
+
+	bool isPixelFormatSupported(uint32_t format);
 };
 
 /***************************************************************************//**


### PR DESCRIPTION
Wayland switches own fd to hang up state and generates
error too late in case of creating surface with
unsupported pixel format. This patch stores supported
pixel formats into a list and check this list
before creating a surface. In case format is unsupported
proper exception is generated.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>