### PR TITLE
Fixes to follow new DRM behavior

### DIFF
--- a/src/displayBackend/DisplayCommandHandler.cpp
+++ b/src/displayBackend/DisplayCommandHandler.cpp
@@ -216,6 +216,14 @@ void DisplayCommandHandler::setConfig(const xendispl_req& req)
 
 	if (configReq->fb_cookie != 0)
 	{
+		if (mConnector->isInitialized())
+		{
+			LOG(mLog, DEBUG) << "Connector " << mConnector->getName()
+							 << " is reinitialized";
+
+			mConnector->release();
+		}
+
 		mConnector->init(configReq->width, configReq->height,
 				mBuffersStorage->getFrameBufferAndCopy(configReq->fb_cookie));
 	}

--- a/src/displayBackend/wayland/FrameBuffer.hpp
+++ b/src/displayBackend/wayland/FrameBuffer.hpp
@@ -22,9 +22,13 @@
 #ifndef SRC_WAYLAND_FRAMEBUFFER_HPP_
 #define SRC_WAYLAND_FRAMEBUFFER_HPP_
 
+#include <mutex>
+
 #include <wayland-client.h>
 
 #include <xen/be/Log.hpp>
+
+#include "Surface.hpp"
 
 #include "DisplayItf.hpp"
 
@@ -71,6 +75,8 @@ public:
 		return mDisplayBuffer;
 	}
 
+	void setSurface(Surface* surface);
+
 protected:
 
 	DisplayItf::DisplayBufferPtr mDisplayBuffer;
@@ -87,6 +93,10 @@ protected:
 private:
 
 	wl_buffer_listener mWlListener;
+
+	Surface* mSurface;
+
+	std::mutex mMutex;
 
 	static void sOnRelease(void *data, wl_buffer *wlBuffer);
 	void onRelease();

--- a/src/displayBackend/wayland/Surface.hpp
+++ b/src/displayBackend/wayland/Surface.hpp
@@ -20,6 +20,8 @@
 
 namespace Wayland {
 
+class WlBuffer;
+
 /***************************************************************************//**
  * Wayland surface class.
  * @ingroup wayland
@@ -43,6 +45,11 @@ public:
 	void draw(DisplayItf::FrameBufferPtr frameBuffer,
 			  FrameCallback callback = nullptr);
 
+	/**
+	 * Clear surface
+	 */
+	void clear();
+
 private:
 
 	friend class Display;
@@ -58,6 +65,7 @@ private:
 
 	wl_surface* mWlSurface;
 	wl_callback *mWlFrameCallback;
+	WlBuffer* mBuffer;
 	bool mTerminate;
 	bool mWaitForFrame;
 	XenBackend::Log mLog;


### PR DESCRIPTION
This PR includes following fixes:
* push null buffer to weston when current buffer is deleted;
* if connector is initialized second time, perform reinitialize.