### PR TITLE
Wayland: clear surface for wl buffer on surface destroy

### DIFF
--- a/src/displayBackend/wayland/Surface.cpp
+++ b/src/displayBackend/wayland/Surface.cpp
@@ -211,14 +211,14 @@ void Surface::init(wl_compositor* compositor)
 
 void Surface::release()
 {
-	clear();
-
-	stop();
-
 	if (mBuffer)
 	{
 		mBuffer->setSurface(nullptr);
 	}
+
+	clear();
+
+	stop();
 
 	if (mThread.joinable())
 	{


### PR DESCRIPTION
Currently surface is cleared in wrong place. As result wl_buffer
keeps pointer to the surface even after surface is deleted. It leads
to crash if the frame buffer is destroyed after connector (surface)
release.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>