### PR TITLE
Fix gcc7 compilation error

### DIFF
--- a/src/displayBackend/DisplayItf.hpp
+++ b/src/displayBackend/DisplayItf.hpp
@@ -22,6 +22,7 @@
 #define SRC_DISPLAYITF_HPP_
 
 #include <exception>
+#include <functional>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Add include <functional> explicitly to DisplayItf.hpp

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>