### PR TITLE
DisplayBackend: use XENDISPL_FIELD_UNIQUE_ID define instead of "id"

### DIFF
--- a/src/displayBackend/DisplayBackend.cpp
+++ b/src/displayBackend/DisplayBackend.cpp
@@ -126,7 +126,7 @@ void DisplayFrontendHandler::createConnector(const string& conPath,
 
 	ref = getXenStore().readInt(conPath + XENDISPL_FIELD_REQ_RING_REF);
 
-	auto id = getXenStore().readString(conPath + "id");
+	auto id = getXenStore().readString(conPath + XENDISPL_FIELD_UNIQUE_ID);
 
 	auto connector = mDisplay->createConnector(id);
 


### PR DESCRIPTION
In new display protocol new field "unique_id" was introduced to distinguish
connectors. This patch add using proper define XENDISPL_FIELD_UNIQUE_ID to
address this field.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>