### PR TITLE
InputBackend: use XENKBD_FIELD_UNIQUE_ID define instead of "id"

### DIFF
--- a/src/inputBackend/InputBackend.cpp
+++ b/src/inputBackend/InputBackend.cpp
@@ -242,8 +242,7 @@ void InputFrontendHandler::onBind()
 	grant_ref_t ref = getXenStore().readUint(
 			getXsFrontendPath() + "/" XENKBD_FIELD_RING_GREF);
 
-	auto id = getXenStore().readString(getXsFrontendPath() + "/id");
-
+	auto id = getXenStore().readString(getXsBackendPath() + "/" XENKBD_FIELD_UNIQUE_ID);
 
 	bool isReqAbs = false;
 	bool isReqMTouch = false;


### PR DESCRIPTION
In new kbd protocol new field "unique_id" was introduced. This patch add
using define XENKBD_FIELD_UNIQUE_ID to address this field.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>