### PR TITLE
Rename VKBD backend device name from VKBD to VINPUT

### DIFF
--- a/src/displayBackend/DisplayBackend.cpp
+++ b/src/displayBackend/DisplayBackend.cpp
@@ -156,5 +156,5 @@ void DisplayBackend::onNewFrontend(domid_t domId, uint16_t devId)
 {
 	addFrontendHandler(FrontendHandlerPtr(
 			new DisplayFrontendHandler(mDisplay, getDeviceName(),
-									   getDomId(), domId, devId)));
+									   domId, devId)));
 }

--- a/src/displayBackend/DisplayBackend.hpp
+++ b/src/displayBackend/DisplayBackend.hpp
@@ -76,15 +76,14 @@ public:
 
 	/**
 	 * @param display   display
-	 * @param backend   backend instance
+	 * @param devName   device name
 	 * @param domId     frontend domain id
 	 * @param devId     frontend device id
 	 */
 	DisplayFrontendHandler(DisplayItf::DisplayPtr display,
 						   const std::string& devName,
-						   domid_t beDomId, domid_t feDomId, uint16_t devId) :
-		FrontendHandlerBase("DisplFrontend", devName,
-							beDomId, feDomId, devId),
+						   domid_t domId, uint16_t devId) :
+		FrontendHandlerBase("DisplFrontend", devName, domId, devId),
 		mDisplay(display),
 		mLog("DisplFrontend") {}
 

--- a/src/inputBackend/InputBackend.cpp
+++ b/src/inputBackend/InputBackend.cpp
@@ -225,9 +225,8 @@ void InputRingBuffer::onFrame(int32_t id)
  ******************************************************************************/
 
 InputFrontendHandler::InputFrontendHandler(const string& devName,
-										   domid_t beDomId, domid_t feDomId,
-										   uint16_t devId) :
-	FrontendHandlerBase("VkbdFrontend", devName, beDomId, feDomId, devId),
+										   domid_t domId, uint16_t devId) :
+	FrontendHandlerBase("VkbdFrontend", devName, domId, devId),
 	mLog("VkbdFrontend")
 {
 	setBackendState(XenbusStateInitWait);
@@ -343,11 +342,10 @@ void InputBackend::onNewFrontend(domid_t domId, uint16_t devId)
 {
 #ifdef WITH_WAYLAND
 	addFrontendHandler(FrontendHandlerPtr(
-			new InputFrontendHandler(XENKBD_DRIVER_NAME, getDomId(),
+			new InputFrontendHandler(XENKBD_DRIVER_NAME,
 									 domId, devId, mDisplay)));
 #else
 	addFrontendHandler(FrontendHandlerPtr(
-			new InputFrontendHandler(XENKBD_DRIVER_NAME, getDomId(),
-									 domId, devId)));
+			new InputFrontendHandler(XENKBD_DRIVER_NAME, domId, devId)));
 #endif
 }

--- a/src/inputBackend/InputBackend.cpp
+++ b/src/inputBackend/InputBackend.cpp
@@ -343,11 +343,11 @@ void InputBackend::onNewFrontend(domid_t domId, uint16_t devId)
 {
 #ifdef WITH_WAYLAND
 	addFrontendHandler(FrontendHandlerPtr(
-			new InputFrontendHandler(getDeviceName(), getDomId(),
+			new InputFrontendHandler(XENKBD_DRIVER_NAME, getDomId(),
 									 domId, devId, mDisplay)));
 #else
 	addFrontendHandler(FrontendHandlerPtr(
-			new InputFrontendHandler(getDeviceName(), getDomId(),
+			new InputFrontendHandler(XENKBD_DRIVER_NAME, getDomId(),
 									 domId, devId)));
 #endif
 }

--- a/src/inputBackend/InputBackend.hpp
+++ b/src/inputBackend/InputBackend.hpp
@@ -100,18 +100,17 @@ public:
 
 	/**
 	 * @param devName      device name
-	 * @param beDomId      backend domain id
-	 * @param feDomId      frontend domain id
+	 * @param domId        frontend domain id
 	 * @param devId        frontend device id
 	 */
 	InputFrontendHandler(const std::string& devName,
-						 domid_t beDomId, domid_t feDomId, uint16_t devId);
+						 domid_t domId, uint16_t devId);
 
 #ifdef WITH_WAYLAND
 	InputFrontendHandler(const std::string& devName,
-			 	 	 	 domid_t beDomId, domid_t feDomId, uint16_t devId,
+			 	 	 	 domid_t domId, uint16_t devId,
 						 Wayland::DisplayPtr display) :
-		InputFrontendHandler(devName, beDomId, feDomId, devId)
+		InputFrontendHandler(devName, domId, devId)
 		{ mDisplay = display; }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,10 +247,10 @@ int main(int argc, char *argv[])
 
 #ifdef WITH_INPUT
 #ifdef WITH_WAYLAND
-			InputBackend inputBackend(XENKBD_DRIVER_NAME,
+			InputBackend inputBackend("vinput",
 					dynamic_pointer_cast<Wayland::Display>(display));
 #else
-			InputBackend inputBackend(XENKBD_DRIVER_NAME);
+			InputBackend inputBackend("vinput");
 #endif
 			inputBackend.start();
 #endif


### PR DESCRIPTION
We've submitted renaming VKBD to VINPUT to Xen. Once these changes are acceptable, we should rename it on our backend side. This commit should be merged once https://github.com/xen-troops/libxenbe/pull/47 is merged.