### PR TITLE
Fix of crash

### DIFF
--- a/src/displayBackend/drm/Dumb.cpp
+++ b/src/displayBackend/drm/Dumb.cpp
@@ -50,7 +50,7 @@ namespace Drm {
 DumbBase::DumbBase(int drmFd, uint32_t width, uint32_t height) :
 	mDrmFd(drmFd),
 	mBufDrmHandle(0),
-	mStride(0),
+	mBackStride(0),
 	mWidth(width),
 	mHeight(height),
 	mName(0),
@@ -102,7 +102,7 @@ void DumbBase::createDumb(uint32_t bpp)
 		throw Exception("Cannot create dumb buffer", errno);
 	}
 
-	mStride = creq.pitch;
+	mBackStride = creq.pitch;
 	mSize = creq.size;
 	mBufDrmHandle = creq.handle;
 }
@@ -187,7 +187,7 @@ void DumbDrm::init(uint32_t bpp, domid_t domId, const GrantRefs& refs)
 	mapDumb();
 
 	DLOG(mLog, DEBUG) << "Create dumb, handle: " << mBufDrmHandle << ", size: "
-					   << mSize << ", stride: " << mStride;
+					   << mSize << ", stride: " << mBackStride;
 }
 
 void DumbDrm::release()
@@ -223,7 +223,7 @@ DumbZCopyFront::DumbZCopyFront(int drmFd,
 	mGnttabBuffer(domId, refs)
 {
 	mBufZCopyFd = mGnttabBuffer.getFd();
-	mStride = 4 * ((width * bpp + 31) / 32);
+	mBackStride = 4 * ((width * bpp + 31) / 32);
 	DLOG(mLog, DEBUG) << "Fd: " << mBufZCopyFd;
 }
 
@@ -352,7 +352,7 @@ void DumbZCopyBack::init(uint32_t bpp, domid_t domId, GrantRefs& refs)
 	DLOG(mLog, DEBUG) << "Create ZCopy back dumb, domId: " << domId
 					  << ", handle: " << mBufDrmHandle
 					  << ", fd: " << mBufDrmFd
-					  << ", size: " << mSize << ", stride: " << mStride;
+					  << ", size: " << mSize << ", stride: " << mBackStride;
 }
 
 void DumbZCopyBack::release()

--- a/src/displayBackend/drm/Dumb.hpp
+++ b/src/displayBackend/drm/Dumb.hpp
@@ -59,7 +59,7 @@ public:
 	/**
 	 * Gets stride
 	 */
-	uint32_t getStride() const override { return mStride; }
+	uint32_t getStride() const override { return mBackStride; }
 
 	/**
 	 * Gets name
@@ -80,7 +80,7 @@ protected:
 
 	int mDrmFd;
 	uint32_t mBufDrmHandle;
-	uint32_t mStride;
+	uint32_t mBackStride;
 	uint32_t mWidth;
 	uint32_t mHeight;
 	uint32_t mName;

--- a/src/displayBackend/drm/Dumb.hpp
+++ b/src/displayBackend/drm/Dumb.hpp
@@ -81,6 +81,7 @@ protected:
 	int mDrmFd;
 	uint32_t mBufDrmHandle;
 	uint32_t mBackStride;
+	uint32_t mFrontStride;
 	uint32_t mWidth;
 	uint32_t mHeight;
 	uint32_t mName;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ DisplayItf::DisplayPtr getDisplay(DisplayMode mode)
 		// DRM
 		return Drm::DisplayPtr(new Drm::Display(gDrmDevice));
 #else
-		throw DisplayItf::Exception("DRM mode is not supported", EINVAL);
+		throw XenBackend::Exception("DRM mode is not supported", EINVAL);
 #endif
 	}
 	else
@@ -208,7 +208,7 @@ DisplayItf::DisplayPtr getDisplay(DisplayMode mode)
 		// Wayland
 		return Wayland::DisplayPtr(new Wayland::Display());
 #else
-		throw DisplayItf::Exception("WAYLAND mode is not supported", EINVAL);
+		throw XenBackend::Exception("WAYLAND mode is not supported", EINVAL);
 #endif
 	}
 }


### PR DESCRIPTION
Backend device can have bigger size of buffer than a frontend device. In that case copying of the frontend buffer is made by lines.