### PR TITLE
Fix compile error for XENDISPL_OP_DBUF_CREATE before v2

### DIFF
--- a/src/displayBackend/DisplayCommandHandler.cpp
+++ b/src/displayBackend/DisplayCommandHandler.cpp
@@ -166,11 +166,6 @@ void DisplayCommandHandler::createDisplayBuffer(const xendispl_req& req)
 {
 	const xendispl_dbuf_create_req* dbufReq = &req.op.dbuf_create;
 
-	DLOG(mLog, DEBUG) << "Handle command [CREATE DBUF], cookie: "
-					  << hex << setfill('0') << setw(16)
-					  << dbufReq->dbuf_cookie
-					  << ", offset: " << dec << dbufReq->data_ofs;
-
 	bool beAllocRefs = dbufReq->flags & XENDISPL_DBUF_FLG_REQ_ALLOC;
 
 	/**
@@ -185,6 +180,11 @@ void DisplayCommandHandler::createDisplayBuffer(const xendispl_req& req)
 #else
 	size_t data_ofs = 0;
 #endif
+
+	DLOG(mLog, DEBUG) << "Handle command [CREATE DBUF], cookie: "
+					  << hex << setfill('0') << setw(16)
+					  << dbufReq->dbuf_cookie
+					  << ", offset: " << dec << data_ofs;
 
 	if (beAllocRefs && data_ofs)
 	{


### PR DESCRIPTION
Fixes: 6bcf9acb219e ("Handle buffer offset passed with XENDISPL_OP_DBUF_CREATE v2")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>