### PR TITLE
Fix of crash v2

### DIFF
--- a/src/displayBackend/drm/Dumb.cpp
+++ b/src/displayBackend/drm/Dumb.cpp
@@ -51,6 +51,7 @@ DumbBase::DumbBase(int drmFd, uint32_t width, uint32_t height) :
 	mDrmFd(drmFd),
 	mBufDrmHandle(0),
 	mBackStride(0),
+	mFrontStride(0),
 	mWidth(width),
 	mHeight(height),
 	mName(0),
@@ -93,6 +94,8 @@ void DumbBase::createDumb(uint32_t bpp)
 {
 	drm_mode_create_dumb creq {0};
 
+	mFrontStride = 4 * ((mWidth * bpp + 31) / 32);
+
 	creq.width = mWidth;
 	creq.height = mHeight;
 	creq.bpp = bpp;
@@ -105,6 +108,10 @@ void DumbBase::createDumb(uint32_t bpp)
 	mBackStride = creq.pitch;
 	mSize = creq.size;
 	mBufDrmHandle = creq.handle;
+	if (mBackStride != mFrontStride)
+	{
+		DLOG(mLog, WARNING) << "Strides are different, frontend stride: " << mFrontStride << ", backend stride: " << mBackStride;
+	}
 }
 
 /*******************************************************************************
@@ -145,8 +152,17 @@ void DumbDrm::copy()
 	}
 
 	DLOG(mLog, DEBUG) << "Copy dumb, handle: " << mBufDrmHandle;
-
-	memcpy(mBuffer, mGnttabBuffer->get(), mSize);
+	if (mGnttabBuffer->size() == mSize)
+	{
+		memcpy(mBuffer, mGnttabBuffer->get(), mSize);
+		return;
+	}
+	auto src = reinterpret_cast<uint8_t*>(mGnttabBuffer->get());
+	auto dst = reinterpret_cast<uint8_t*>(mBuffer);
+	for (unsigned int i = 0; i < mHeight; i++)
+	{
+		memcpy(dst + i * mBackStride, src + i * mFrontStride, mFrontStride);
+	}
 }
 
 /*******************************************************************************

--- a/src/displayBackend/drm/Dumb.cpp
+++ b/src/displayBackend/drm/Dumb.cpp
@@ -50,7 +50,7 @@ namespace Drm {
 DumbBase::DumbBase(int drmFd, uint32_t width, uint32_t height) :
 	mDrmFd(drmFd),
 	mBufDrmHandle(0),
-	mStride(0),
+	mBackStride(0),
 	mWidth(width),
 	mHeight(height),
 	mName(0),
@@ -102,7 +102,7 @@ void DumbBase::createDumb(uint32_t bpp)
 		throw Exception("Cannot create dumb buffer", errno);
 	}
 
-	mStride = creq.pitch;
+	mBackStride = creq.pitch;
 	mSize = creq.size;
 	mBufDrmHandle = creq.handle;
 }
@@ -187,7 +187,7 @@ void DumbDrm::init(uint32_t bpp, domid_t domId, const GrantRefs& refs)
 	mapDumb();
 
 	DLOG(mLog, DEBUG) << "Create dumb, handle: " << mBufDrmHandle << ", size: "
-					   << mSize << ", stride: " << mStride;
+					   << mSize << ", stride: " << mBackStride;
 }
 
 void DumbDrm::release()
@@ -223,7 +223,7 @@ DumbZCopyFront::DumbZCopyFront(int drmFd,
 	mGnttabBuffer(domId, refs)
 {
 	mBufZCopyFd = mGnttabBuffer.getFd();
-	mStride = 4 * ((width * bpp + 31) / 32);
+	mBackStride = 4 * ((width * bpp + 31) / 32);
 	DLOG(mLog, DEBUG) << "Fd: " << mBufZCopyFd;
 }
 
@@ -352,7 +352,7 @@ void DumbZCopyBack::init(uint32_t bpp, domid_t domId, GrantRefs& refs)
 	DLOG(mLog, DEBUG) << "Create ZCopy back dumb, domId: " << domId
 					  << ", handle: " << mBufDrmHandle
 					  << ", fd: " << mBufDrmFd
-					  << ", size: " << mSize << ", stride: " << mStride;
+					  << ", size: " << mSize << ", stride: " << mBackStride;
 }
 
 void DumbZCopyBack::release()

--- a/src/displayBackend/drm/Dumb.hpp
+++ b/src/displayBackend/drm/Dumb.hpp
@@ -59,7 +59,7 @@ public:
 	/**
 	 * Gets stride
 	 */
-	uint32_t getStride() const override { return mStride; }
+	uint32_t getStride() const override { return mBackStride; }
 
 	/**
 	 * Gets name
@@ -80,7 +80,7 @@ protected:
 
 	int mDrmFd;
 	uint32_t mBufDrmHandle;
-	uint32_t mStride;
+	uint32_t mBackStride;
 	uint32_t mWidth;
 	uint32_t mHeight;
 	uint32_t mName;

--- a/src/displayBackend/drm/Dumb.hpp
+++ b/src/displayBackend/drm/Dumb.hpp
@@ -81,6 +81,7 @@ protected:
 	int mDrmFd;
 	uint32_t mBufDrmHandle;
 	uint32_t mBackStride;
+	uint32_t mFrontStride;
 	uint32_t mWidth;
 	uint32_t mHeight;
 	uint32_t mName;


### PR DESCRIPTION
Fix of crash when strides are different

There are situations when a backend DRM driver makes a buffer bigger size than a frontend buffer.
For example, i915 driver counts a stride by a multiplication of a display width in pixesl on a number of bytes per pixel
and aligns it up to 64 bytes. Then a size of the buffer is counted by a multiplication of the stride on a display height.
So we have the backend buffer is bigger than the frontend buffer with an unaligned stride.
It causes a crash when bytes are coping from the frontend buffer to the backend buffer with the size of the backend buffer.

In a case when we do not use zero-copying the situation can be fixed by coping of lines of the frontend buffer to beginning of lines of the backend buffer one by one.

This fix is only suitable in the case without zero-copying. In the case of zero-copying a frontend should prepare its buffer with a corresponding stride.
There is a warning alarms about the situation.

Signed-off-by: Alexander Sychev <santucco@gmail.com>