### PR TITLE
Remove explicit specifier from constructor of class Display

### DIFF
--- a/src/displayBackend/drm/Display.hpp
+++ b/src/displayBackend/drm/Display.hpp
@@ -50,7 +50,7 @@ public:
 	/**
 	 * @param name device name
 	 */
-	explicit Display(const std::string& name, bool disable_zcopy = false);
+	Display(const std::string& name, bool disable_zcopy = false);
 
 	~Display();
 


### PR DESCRIPTION
Specifier 'explicit' is used to avoid the unexpected type deduction.
The constructor of class Display has 2 input parameters of different type.
So, it is not necessary to the explicit specifier here, because it is not possible
to be int and bool types simultaneously.
Summary: specifier explicit does not bring any advantages and may be removed.


Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>