### PR TITLE
Handle the exception in call-back function

### DIFF
--- a/src/displayBackend/wayland/Display.cpp
+++ b/src/displayBackend/wayland/Display.cpp
@@ -434,24 +434,22 @@ void Display::registryHandler(wl_registry *registry, uint32_t id,
 	{
 		mCompositor.reset(new Compositor(mWlDisplay, registry, id, version));
 	}
-
-	if (interface == "wl_shell")
+	else if (interface == "wl_shell")
 	{
 		mShell.reset(new Shell(registry, id, version));
 	}
-
-	if (interface == "wl_shm")
+	else if (interface == "wl_shm")
 	{
 		mSharedMemory.reset(new SharedMemory(registry, id, version));
 	}
 #ifdef WITH_IVI_EXTENSION
-	if (interface == "ivi_application")
+	else if (interface == "ivi_application")
 	{
 		mIviApplication.reset(new IviApplication(registry, id, version));
 	}
 #endif
 #ifdef WITH_INPUT
-	if (interface == "wl_seat")
+	else if (interface == "wl_seat")
 	{
 		mSeat.reset(new Seat(registry, id, Seat::cVersion));
 	}
@@ -463,11 +461,11 @@ void Display::registryHandler(wl_registry *registry, uint32_t id,
 		{
 			mWaylandDrm.reset(new WaylandDrm(registry, id, version));
 		}
-		if (interface == "wl_kms")
+		else if (interface == "wl_kms")
 		{
 			mWaylandKms.reset(new WaylandKms(registry, id, version));
 		}
-		if (interface == "zwp_linux_dmabuf_v1")
+		else if (interface == "zwp_linux_dmabuf_v1")
 		{
 			mWaylandLinuxDmabuf.reset(new WaylandLinuxDmabuf(registry, id, version));
 		}

--- a/src/displayBackend/wayland/Display.cpp
+++ b/src/displayBackend/wayland/Display.cpp
@@ -408,8 +408,14 @@ void Display::sWaylandLog(const char* fmt, va_list arg)
 void Display::sRegistryHandler(void *data, wl_registry *registry, uint32_t id,
 							   const char *interface, uint32_t version)
 {
-	static_cast<Display*>(data)->registryHandler(registry, id, interface,
-												 version);
+	try
+	{
+		static_cast<Display*>(data)->registryHandler(registry, id, interface, version);
+	}
+	catch(const std::exception& err)
+	{
+		LOG("Wayland", ERROR) << err.what();
+	}
 }
 
 void Display::sRegistryRemover(void *data, struct wl_registry *registry,
@@ -498,7 +504,10 @@ void Display::init()
 		throw Exception("Can't get registry", errno);
 	}
 
-	wl_registry_add_listener(mWlRegistry, &mWlRegistryListener, this);
+	if(wl_registry_add_listener(mWlRegistry, &mWlRegistryListener, this) == -1)
+	{
+		throw Exception("Can not add the listener.", errno);
+	};
 
 	wl_display_dispatch(mWlDisplay);
 	wl_display_roundtrip(mWlDisplay);


### PR DESCRIPTION
There is a list of the callback functions, to be called from the kernel of Wayland
Below is the sample of callback call (see wl_proxy_create_for_global)
    wl_list_for_each(listener, &display->global_listener_list, link)
                    (*listener->handler)(display, &proxy->base, listener->data);
    
If callback function throws an exception it rather brings the crash,  because of not caught exception.
Summary: all code that potentially can throw an exception has to be wrapped in try-catch block.
The following changes are done
File Display.cpp
1.Display::sRegistryHandler:
The call 'static_cast<Display*>(data)->registryHandler(registry, id, interface, version);' wrapped
in try-catch block. In the case of the exception, the error is written in log.
2.Display::sRegistryRemove:fix that does not have a relation to the issue, but improve the 'safe' behavior
Display::sRegistryRemove: the call of wl_registry_add_listener is check against the returned value.
If result is -1 the exception is thrown.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>