### PR TITLE
Handle an exception in event handler.

### DIFF
--- a/src/displayBackend/DisplayBackend.cpp
+++ b/src/displayBackend/DisplayBackend.cpp
@@ -100,9 +100,19 @@ void DisplayFrontendHandler::onBind()
 	{
 		LOG(mLog, DEBUG) << "Found connector: " << conIndex;
 
-		createConnector(conBasePath + to_string(conIndex) + "/",
-						conIndex, buffersStorage);
-
+		try 
+		{
+			createConnector(conBasePath + to_string(conIndex) + "/",
+					conIndex, buffersStorage);
+		}
+		catch(const std::exception& err)
+		{
+			LOG(mLog, ERROR) << " Connector " 
+					<< conBasePath 
+					<< conIndex
+					<< " is not created because of "
+					<< err.what();
+		}
 		conIndex++;
 	}
 }


### PR DESCRIPTION
There is a virtual method DisplayFrontendHandler::onBind.
This method is called as reaction at the event 'onStateConnected'.
If exception thrown inside of onBind goes outside the function,
the behavior is unpredictable, because there are not any exception handlers
inside of onStateConnected. To fix the problem, the 2 ways are visible
1.Handle the exception inside of onBind
2.Handle the exception inside of onStateConnected event.
    
The 1st approach has been selected because it allows to localize the problem and
does not change the source code outside of the component.
It is proposed to 'eat' the exception and log the error.
    
The 2nd approach should work as well, and exception will be 'eaten' as well,
but it is possible do not change the state in the case of error.
    
The scope of fix
The call of createConnector is wrapped in try-catch block.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>