### PR TITLE
Parameter of DisplayBackend::DisplayBackend is not check for null

### DIFF
--- a/src/displayBackend/DisplayBackend.cpp
+++ b/src/displayBackend/DisplayBackend.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <cassert>
 
 #include <xen/be/XenStore.hpp>
 
@@ -155,6 +156,8 @@ DisplayBackend::DisplayBackend(DisplayPtr display,
 	BackendBase("DisplBackend", deviceName),
 	mDisplay(display)
 {
+	assert(mDisplay);
+
 	mDisplay->start();
 }
 


### PR DESCRIPTION
There is an input parameter 'display', the value may be nullptr.
To avoid the unexpected behavior, the assert is used to 'fire' the problem
in DEBUG mode.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>