### PR TITLE
DevInputBase::~DevInputBase not cought an exception

### DIFF
--- a/src/inputBackend/input/DevInput.cpp
+++ b/src/inputBackend/input/DevInput.cpp
@@ -49,7 +49,14 @@ DevInputBase::DevInputBase(const string& name) :
 
 DevInputBase::~DevInputBase()
 {
-	stop();
+	try
+	{
+		stop();
+	}
+	catch(const std::exception& err)
+	{
+		LOG(mLog, ERROR) << err.what();
+	}
 	release();
 }
 


### PR DESCRIPTION
The function stop() is called from destructor of DevInputBase
DevInputBase::~DevInputBase()
{
stop();
....
}
Where stop delegates the call to PollFd::stop
mPollFd->stop();

Function PollFd::stop may throw the exception in the case of 'write' fail.

See the code:

void PollFd::stop()
{
uint8_t data = 0xFF;
if (write(mPipeFds[PipeType::WRITE], &data, sizeof(data)) < 0)
{
throw Exception("Error writing pipe", errno);
}
}
To avoid unexpected crash - the call of stop is wrapped into try-catch block.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>