### PR TITLE
Potential crash because of exception

### DIFF
--- a/src/displayBackend/wayland/WaylandZCopy.cpp
+++ b/src/displayBackend/wayland/WaylandZCopy.cpp
@@ -78,7 +78,14 @@ void WaylandZCopy::onDevice(const string& name)
 
 	LOG(mLog, DEBUG) << "onDevice name: " << name;
 
-	mDrmDevice.reset(new Drm::DisplayWayland(name));
+	try
+	{
+		mDrmDevice.reset(new Drm::DisplayWayland(name));
+	}
+	catch(const std::exception& err)
+	{
+		LOG(mLog, ERROR) << err.what();
+	}
 
 	authenticate();
 }


### PR DESCRIPTION
Reference:https://github.com/xen-troops/displ_be/issues/112

The event handler (onDevice) does not catch an exception.
The code is wrapped into try-catch block

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>