### PR TITLE
DisplayCommandHandler: add the verification of nullptr

### DIFF
--- a/src/displayBackend/DisplayCommandHandler.cpp
+++ b/src/displayBackend/DisplayCommandHandler.cpp
@@ -20,6 +20,7 @@
 
 #include "DisplayCommandHandler.hpp"
 
+#include <cassert>
 #include <iomanip>
 
 #include <xen/be/Exception.hpp>
@@ -89,6 +90,11 @@ DisplayCommandHandler::DisplayCommandHandler(
 	mEventId(0),
 	mLog("CommandHandler")
 {
+	assert(display);
+	assert(connector);
+	assert(buffersStorage);
+	assert(eventBuffer);
+	
 	LOG(mLog, DEBUG) << "Create command handler, connector name: "
 					 << mConnector->getName();
 }


### PR DESCRIPTION
Add the set of the 'assert's to simplify the initialization errors
during the object creation.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>