### PR TITLE
DisplayBackend: Add display name to the EDID

### DIFF
--- a/src/displayBackend/common/ConnectorBase.cpp
+++ b/src/displayBackend/common/ConnectorBase.cpp
@@ -162,6 +162,13 @@ void ConnectorBase::edidPutDetailedTiming(edid* edidBlock, int index,
 										  uint32_t xres, uint32_t yres,
 										  uint32_t dpi)
 {
+	/*
+	 * Detailed timing descriptors, in decreasing preference order,
+	 * followed by Display descriptors.
+	 *
+	 * We only provide a single timing here which corresponds to
+	 * XenStore configuration of this connector.
+	 */
 	detailed_timing* desc = &edidBlock->detailed_timings[index];
 	detailed_pixel_timing* pixelData = &desc->data.pixel_data;
 
@@ -234,16 +241,7 @@ void ConnectorBase::edidPutTimings(edid* edidBlock)
 	 * We do not provide any, but detailed timings.
 	 */
 	memset(edidBlock->standard_timings, 0x01,
-		   sizeof(edidBlock->standard_timings));
-
-	/*
-	 * Detailed timing descriptors, in decreasing preference order,
-	 * followed by Display descriptors.
-	 *
-	 * We only provide a single timing here which corresponds to
-	 * XenStore configuration of this connector.
-	 */
-	edidPutDetailedTiming(edidBlock, 0, mCfgWidth, mCfgHeight, EDID_DPI);
+		   sizeof(edidBlock->standard_timings));	
 }
 
 size_t ConnectorBase::getEDID(grant_ref_t startDirectory, uint32_t size)
@@ -266,6 +264,7 @@ size_t ConnectorBase::getEDID(grant_ref_t startDirectory, uint32_t size)
 	edidPutEssentials(edidBlock);
 	edidPutColorSpace(edidBlock);
 	edidPutTimings(edidBlock);
+	edidPutDetailedTiming(edidBlock, 0, mCfgWidth, mCfgHeight, EDID_DPI);
 	edidPutBlockCheckSum(static_cast<uint8_t*>(edidBuffer.get()));
 
 	return XENDISPL_EDID_BLOCK_SIZE;

--- a/src/displayBackend/common/ConnectorBase.hpp
+++ b/src/displayBackend/common/ConnectorBase.hpp
@@ -89,7 +89,7 @@ private:
 	void edidPutColorSpace(edid* edidBlock);
 
 	/**
-	 * * Put supported timings into the EDID
+	 * * Put established and standard timings into the EDID
 	 * * @param edidBlock buffer with EDID block
 	 * */
 	void edidPutTimings(edid* edidBlock);
@@ -97,7 +97,7 @@ private:
 	/**
 	 * Put detailed timings into the EDID
 	 * @param edidBlock buffer with EDID block
-	 * @param index     index of the detailed timings structure
+	 * @param index     index amid 4 possible 18 byte descriptors
 	 * @param xres      desired X resolution
 	 * @param yres      desired Y resolution
 	 * @param dpi       desired DPI

--- a/src/displayBackend/common/ConnectorBase.hpp
+++ b/src/displayBackend/common/ConnectorBase.hpp
@@ -95,6 +95,14 @@ private:
 	void edidPutTimings(edid* edidBlock);
 
 	/**
+	 * * Put display related data into the EDID
+	 * * @param edidBlock buffer with EDID block
+	 * * @param descriptorIndex index amid 4 possible
+	 * *        18 byte descriptors
+	 * */
+	void edidPutDisplayDescritor(edid* edidBlock, int descriptorIndex);
+
+	/**
 	 * Put detailed timings into the EDID
 	 * @param edidBlock buffer with EDID block
 	 * @param index     index amid 4 possible 18 byte descriptors

--- a/src/displayBackend/common/drm_edid.h
+++ b/src/displayBackend/common/drm_edid.h
@@ -85,9 +85,11 @@ struct detailed_pixel_timing {
 	uint8_t misc;
 } __attribute__((packed));
 
+#define DRM_EDID_DISPLAY_NAME_MAX_LENGTH 13
+
 /* If it's not pixel timing, it'll be one of the below */
 struct detailed_data_string {
-	uint8_t str[13];
+	uint8_t str[DRM_EDID_DISPLAY_NAME_MAX_LENGTH];
 } __attribute__((packed));
 
 struct detailed_data_monitor_range {


### PR DESCRIPTION
Use Display Product Name (ASCII) String Descriptor to
store display name. This may be critical for some OS like Android.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>