### PR TITLE
Correctly track Surface object

### DIFF
--- a/src/displayBackend/DisplayBackend.cpp
+++ b/src/displayBackend/DisplayBackend.cpp
@@ -62,7 +62,7 @@ CtrlRingBuffer::CtrlRingBuffer(DisplayPtr display,
 							   evtchn_port_t port, grant_ref_t ref) :
 	RingBufferInBase<xen_displif_back_ring, xen_displif_sring,
 					 xendispl_req, xendispl_resp>(domId, port, ref),
-	mCommandHandler(display, connector, buffersStorage, eventBuffer),
+	mCommandHandler(display, std::move(connector), buffersStorage, eventBuffer),
 	mLog("ConCtrlRing")
 {
 	LOG(mLog, DEBUG) << "Create ctrl ring buffer";
@@ -138,7 +138,7 @@ void DisplayFrontendHandler::createConnector(const string& conPath,
 
 	CtrlRingBufferPtr ctrlRingBuffer(
 			new CtrlRingBuffer(mDisplay,
-							   connector,
+							   std::move(connector),
 							   bufferStorage,
 							   eventRingBuffer,
 							   getDomId(), port, ref));

--- a/src/displayBackend/DisplayCommandHandler.cpp
+++ b/src/displayBackend/DisplayCommandHandler.cpp
@@ -84,14 +84,14 @@ DisplayCommandHandler::DisplayCommandHandler(
 		BuffersStoragePtr buffersStorage,
 		EventRingBufferPtr eventBuffer) :
 	mDisplay(display),
-	mConnector(connector),
+	mConnector(std::move(connector)),
 	mBuffersStorage(buffersStorage),
 	mEventBuffer(eventBuffer),
 	mEventId(0),
 	mLog("CommandHandler")
 {
 	assert(display);
-	assert(connector);
+	assert(mConnector);
 	assert(buffersStorage);
 	assert(eventBuffer);
 	

--- a/src/displayBackend/common/DisplayItf.hpp
+++ b/src/displayBackend/common/DisplayItf.hpp
@@ -185,7 +185,7 @@ public:
 	virtual size_t getEDID(grant_ref_t startDirectory, uint32_t size) const = 0;
 };
 
-typedef std::shared_ptr<Connector> ConnectorPtr;
+typedef std::unique_ptr<Connector> ConnectorPtr;
 
 /***************************************************************************//**
  * Display interface class.

--- a/src/displayBackend/wayland/Connector.cpp
+++ b/src/displayBackend/wayland/Connector.cpp
@@ -44,6 +44,11 @@ Connector::Connector(domid_t domId, const std::string& name,
 
 Connector::~Connector()
 {
+	if (mSurface)
+	{
+		mSurface->disableCallback();
+	}
+
 	if (isInitialized())
 	{
 		release();

--- a/src/displayBackend/wayland/Connector.cpp
+++ b/src/displayBackend/wayland/Connector.cpp
@@ -22,6 +22,7 @@
 #include "Connector.hpp"
 #include "Exception.hpp"
 #include "SurfaceManager.hpp"
+#include "FrameBuffer.hpp"
 
 using DisplayItf::FrameBufferPtr;
 
@@ -76,6 +77,7 @@ void Connector::pageFlip(FrameBufferPtr frameBuffer, FlipCallback cbk)
 	}
 
 	mSurface->draw(frameBuffer, cbk);
+	dynamic_cast<WlBuffer*>(frameBuffer.get())->setSurface(mSurface);
 }
 
 /*******************************************************************************

--- a/src/displayBackend/wayland/Connector.hpp
+++ b/src/displayBackend/wayland/Connector.hpp
@@ -207,7 +207,7 @@ private:
 };
 #endif
 
-typedef std::shared_ptr<Connector> ConnectorPtr;
+typedef std::unique_ptr<Connector> ConnectorPtr;
 
 }
 

--- a/src/displayBackend/wayland/FrameBuffer.cpp
+++ b/src/displayBackend/wayland/FrameBuffer.cpp
@@ -41,18 +41,17 @@ WlBuffer::WlBuffer(DisplayBufferPtr displayBuffer,
 	mWidth(width),
 	mHeight(height),
 	mWlBuffer(nullptr),
-	mLog("WlBuffer"),
-	mSurface(nullptr)
+	mLog("WlBuffer")
 {
 }
 
 WlBuffer::~WlBuffer()
 {
 	lock_guard<mutex> lock(mMutex);
+	auto surfaceSharedPtr = mSurface.lock();
 
-	if (mSurface)
-	{
-		mSurface->clear();
+	if (surfaceSharedPtr) {
+		surfaceSharedPtr->clear();
 	}
 
 	if (mWlBuffer)
@@ -95,11 +94,11 @@ void WlBuffer::onRelease()
 
 	LOG(mLog, DEBUG) << "Release";
 
-	mSurface = nullptr;
+	mSurface.reset();
 }
 
 
-void WlBuffer::setSurface(Surface* surface)
+void WlBuffer::setSurface(std::weak_ptr<Surface> surface)
 {
 	lock_guard<mutex> lock(mMutex);
 

--- a/src/displayBackend/wayland/FrameBuffer.hpp
+++ b/src/displayBackend/wayland/FrameBuffer.hpp
@@ -73,7 +73,7 @@ public:
 		return mDisplayBuffer;
 	}
 
-	void setSurface(Surface* surface);
+	void setSurface(std::weak_ptr<Surface> surface);
 
 protected:
 
@@ -92,7 +92,7 @@ private:
 
 	wl_buffer_listener mWlListener;
 
-	Surface* mSurface;
+	std::weak_ptr<Surface> mSurface;
 
 	std::mutex mMutex;
 

--- a/src/displayBackend/wayland/Surface.cpp
+++ b/src/displayBackend/wayland/Surface.cpp
@@ -54,6 +54,18 @@ Surface::~Surface()
  * Public
  ******************************************************************************/
 
+void Surface::disableCallback()
+{
+	unique_lock<mutex> lock(mMutex);
+
+	mStoredCallback = nullptr;
+	if (mWlFrameCallback)
+	{
+		wl_callback_destroy(mWlFrameCallback);
+		mWlFrameCallback = nullptr;
+	}
+}
+
 void Surface::draw(FrameBufferPtr frameBuffer,
 				   FrameCallback callback)
 {
@@ -212,18 +224,13 @@ void Surface::init(wl_compositor* compositor)
 
 void Surface::release()
 {
+	disableCallback();
 	clear();
-
 	stop();
 
 	if (mThread.joinable())
 	{
 		mThread.join();
-	}
-
-	if (mWlFrameCallback)
-	{
-		wl_callback_destroy(mWlFrameCallback);
 	}
 
 	if (mWlSurface)

--- a/src/displayBackend/wayland/Surface.cpp
+++ b/src/displayBackend/wayland/Surface.cpp
@@ -89,8 +89,6 @@ void Surface::draw(FrameBufferPtr frameBuffer,
 		throw Exception("FrameBuffer must have type WlBuffer.", EINVAL);
 	}
 
-	mBuffer->setSurface(this);
-	
 	wl_surface_damage(mWlSurface, 0, 0,
 					  mBuffer->getWidth(),
 					  mBuffer->getHeight());
@@ -214,11 +212,6 @@ void Surface::init(wl_compositor* compositor)
 
 void Surface::release()
 {
-	if (mBuffer)
-	{
-		mBuffer->setSurface(nullptr);
-	}
-
 	clear();
 
 	stop();

--- a/src/displayBackend/wayland/Surface.hpp
+++ b/src/displayBackend/wayland/Surface.hpp
@@ -50,6 +50,11 @@ public:
 	 */
 	void clear();
 
+	/**
+	 * Disable callback from Wayland
+	 */
+	void disableCallback();
+
 private:
 
 	friend class Display;


### PR DESCRIPTION
With patch c6fde3bad5 to the WlBuffer was
added logic which may call clear() method on
the Surface object. The main issue is there
are several WlBuffer objects and only one Surface.
Since raw ptr was used, memory issues may appear.
he current code adds weak_pt(not shared_pt - since
we don't want to change the overcomplicated
destruction process).

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>